### PR TITLE
add: Add custom format for multi audio and multi subtitiles

### DIFF
--- a/custom_formats/Multi-Audio.yml
+++ b/custom_formats/Multi-Audio.yml
@@ -1,0 +1,13 @@
+name: Multi-Audio
+description: Used to grab releases with multi audio, normally the ones from CR or
+  NF
+tags:
+- anime
+- custom
+conditions:
+- name: Multi Audio
+  negate: false
+  pattern: Multi-Audio
+  required: true
+  type: release_title
+tests: []

--- a/custom_formats/Multi-Sub.yml
+++ b/custom_formats/Multi-Sub.yml
@@ -1,0 +1,13 @@
+name: Multi-Sub
+description: Used to grab releases with multiple subtitles, normally the ones from
+  CR or NF
+tags:
+- anime
+- custom
+conditions:
+- name: Multi Sub
+  negate: false
+  pattern: Multi-Sub
+  required: false
+  type: release_title
+tests: []

--- a/profiles/Anime 1080p.yml
+++ b/profiles/Anime 1080p.yml
@@ -21,9 +21,7 @@ upgradesAllowed: true
 minCustomFormatScore: 0
 upgradeUntilScore: 10000
 minScoreIncrement: 1
-custom_formats: []
-custom_formats_radarr: []
-custom_formats_sonarr:
+custom_formats:
 - name: Anime Tier 1
   score: 1400
 - name: Anime Tier 2
@@ -66,10 +64,14 @@ custom_formats_sonarr:
   score: 200
 - name: Anime Dual Audio
   score: 101
+- name: Multi-Audio
+  score: 101
 - name: Uncensored
   score: 101
 - name: Anime WEB Tier 6
   score: 100
+- name: Multi-Subs
+  score: 10
 - name: CR
   score: 7
 - name: DSNP
@@ -110,6 +112,8 @@ custom_formats_sonarr:
   score: -10000
 - name: AV1
   score: -10000
+custom_formats_radarr: []
+custom_formats_sonarr: []
 qualities:
 - id: -5
   name: Bluray/REMUX 1080p

--- a/regex_patterns/Multi-Audio.yml
+++ b/regex_patterns/Multi-Audio.yml
@@ -1,0 +1,14 @@
+name: Multi-Audio
+pattern: ([Mm]ulti(?:ple)?.*[ ._-]?[Aa]udio?)
+description: ''
+tags:
+- TRaSH
+tests:
+- id: 1
+  input: 'anime name S01E01 episode name 1080p DSNP WEB-DL MULTi AAC2.0 H 264-VARYG
+    (anime name org, Multi-Audio, Multi-Subs) '
+  expected: true
+- id: 2
+  input: '[ToonsHub] anime name S01E01 1080p AMZN WEB-DL DDP2.0 H.264 (anime name
+    orig, Multi-Audio, Multi-Subs) '
+  expected: true

--- a/regex_patterns/Multi-Sub.yml
+++ b/regex_patterns/Multi-Sub.yml
@@ -1,0 +1,13 @@
+name: Multi-Sub
+pattern: ([Mm]ulti(?:ple)?.*[ ._-]?[Ss]ub(?:tile)?)
+description: ''
+tags:
+- custom
+tests:
+- id: 1
+  input: ' [Erai-raws] anime name - 01 [1080p CR WEB-DL AVC AAC][MultiSub][X000000] '
+  expected: true
+- id: 2
+  input: '[ToonsHub] anime name S01E01 1080p AMZN WEB-DL DDP2.0 H.265 (anime name
+    org, Dual-Audio, Multi-Subs)'
+  expected: true


### PR DESCRIPTION
This one are not from Trash, sadly the one from trash https://trash-guides.info/Sonarr/sonarr-collection-of-custom-formats/#multi is for french and german  and not for anime, they are custom one based from my own custom formats
Add custom format for multi audio and multi subtitles, with default arbitrary values
Also add scoring in Anime profile for Radarr (some movies can be only added on Radarr)