### PR TITLE
Fix: Error importing custom formats to Radarr

### DIFF
--- a/profiles/Anime 1080p.yml
+++ b/profiles/Anime 1080p.yml
@@ -22,26 +22,6 @@ minCustomFormatScore: 0
 upgradeUntilScore: 10000
 minScoreIncrement: 1
 custom_formats:
-- name: Anime Tier 1
-  score: 1400
-- name: Anime Tier 2
-  score: 1300
-- name: Anime Tier 3
-  score: 1200
-- name: Anime Tier 4
-  score: 1100
-- name: Remux Tier 01 - Sonarr
-  score: 1050
-- name: Anime Tier 5
-  score: 1000
-- name: Remux Tier 02 - Sonarr
-  score: 1000
-- name: Anime Tier 6
-  score: 900
-- name: Anime Tier 7
-  score: 800
-- name: Anime Tier 8
-  score: 700
 - name: Anime WEB Tier 1
   score: 600
 - name: Anime WEB Tier 2
@@ -72,8 +52,6 @@ custom_formats:
   score: 100
 - name: Multi-Subs
   score: 10
-- name: CR
-  score: 7
 - name: DSNP
   score: 6
 - name: NF
@@ -113,7 +91,29 @@ custom_formats:
 - name: AV1
   score: -10000
 custom_formats_radarr: []
-custom_formats_sonarr: []
+custom_formats_sonarr:
+- name: Anime Tier 1
+  score: 1400
+- name: Anime Tier 2
+  score: 1300
+- name: Anime Tier 3
+  score: 1200
+- name: Anime Tier 4
+  score: 1100
+- name: Remux Tier 01 - Sonarr
+  score: 1050
+- name: Anime Tier 5
+  score: 1000
+- name: Remux Tier 02 - Sonarr
+  score: 1000
+- name: Anime Tier 6
+  score: 900
+- name: Anime Tier 7
+  score: 800
+- name: Anime Tier 8
+  score: 700
+- name: CR
+  score: 7
 qualities:
 - id: -5
   name: Bluray/REMUX 1080p


### PR DESCRIPTION
Hi, some of the custom format are not valid for radarr, they use source exclusive of sonarr like bluray_raw so this cant be imported in radarr. I move them to only apply to sonarr, seeing other implementation in trash, is the same result