### PR TITLE
fix(format): web_dl negated to false in TrueHD (WEB)

### DIFF
--- a/custom_formats/TrueHD (WEB).yml
+++ b/custom_formats/TrueHD (WEB).yml
@@ -5,7 +5,7 @@ tags:
 - Audio
 conditions:
 - name: WEB-DL
-  negate: true
+  negate: false
   required: true
   source: web_dl
   type: source


### PR DESCRIPTION
Based on the description of this format, I believe `web_dl` should not be negated.

I've noticed that this causes WEB-DL releases to outscore Bluray in profiles such as `Movies 2160p HQ`